### PR TITLE
Fix to revert default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ module "vpc" {
   enable_dns_support = true
   enable_dns_hostnames = true
   enable_classiclink = false   # "true" supported only for 10.1.0.0/16 VPC IP address block per AWS documentation
+  create_private_subnet  = true
 }
 ```

--- a/variables.tf
+++ b/variables.tf
@@ -27,5 +27,5 @@ variable "instance_tenancy" {
 }
 
 variable "create_private_subnet" {
-  default = false
+  default = true
 }


### PR DESCRIPTION
Private subnets was created by default before introducing this variable.